### PR TITLE
Fixed #316

### DIFF
--- a/dist/css/arizona-bootstrap.css
+++ b/dist/css/arizona-bootstrap.css
@@ -17566,6 +17566,7 @@ have been deprecated in Bootstrap 4.
   font-family: "Material Icons Sharp";
   font-size: 2em;
   content: "expand_more";
+  font-variant-ligatures: no-common-ligatures;
 }
 
 .accordion .card-header .btn[aria-expanded="true"]::after {


### PR DESCRIPTION
`font-variant-ligatures: no-common-ligatures; `
property added to resolve the safari icon missing bug in accordion component.